### PR TITLE
Cross-entity invoke lowers to this.Rel.Action(args)

### DIFF
--- a/Poly.Tests/DomainModeling/Lowering/CrossEntityInvokeHostAbiTests.cs
+++ b/Poly.Tests/DomainModeling/Lowering/CrossEntityInvokeHostAbiTests.cs
@@ -1,0 +1,93 @@
+using Poly.DomainModeling;
+using Poly.DomainModeling.Lowering;
+using Poly.DomainModeling.Ontology;
+using Poly.DomainModeling.Runtime;
+using Poly.Interpretation.CSharp;
+
+namespace Poly.Tests.DomainModeling.Lowering;
+
+public class CrossEntityInvokeHostAbiTests {
+    private static (Entity orchestrator, Entity service, Domain domain) CreateLinkedDomain() {
+        var status = new Property("Status", new DomainTypeReference("Text"), []);
+        var service = new Entity("Service", [status], Actions: [
+            new Poly.DomainModeling.Ontology.Action("Process", InvocationResult.Void, [], [
+                new AssignEffect(DomainExpression.Property("Status"),
+                    DomainExpression.Literal("processed"))
+            ], [])
+        ], [], []);
+        var orchestrator = new Entity("Orchestrator", [], Actions: [
+            new Poly.DomainModeling.Ontology.Action("Run", InvocationResult.Void, [], [
+                new InvokeActionEffect("Process", [], TargetRelationship: "ServiceCall")
+            ], [])
+        ], [], []);
+        var rel = new Relationship("ServiceCall",
+            new DomainTypeReference("Orchestrator"), new DomainTypeReference("Service"),
+            RelationshipCardinality.OneToOne, []);
+        var domain = DomainTestFactory.Create("Test", [orchestrator, service], [rel]);
+        return (orchestrator, service, domain);
+    }
+
+    [Test]
+    public async Task CrossEntityInvoke_LowersToNavCall_NotGatedOnFlag() {
+        var (orchestrator, _, _) = CreateLinkedDomain();
+        var off = new EffectLoweringPass(orchestrator, new LoweringContext(
+            new Parameter("entity"), LowerStageTransitions: false));
+        var on = new EffectLoweringPass(orchestrator, new LoweringContext(
+            new Parameter("entity"), LowerStageTransitions: true, UseThisReference: true));
+
+        var effect = new InvokeActionEffect("Process", [], TargetRelationship: "ServiceCall");
+        var loweredOff = off.TryLowerVmNode(effect);
+        var loweredOn = on.TryLowerVmNode(effect);
+
+        await Assert.That(loweredOff).IsNotNull();
+        await Assert.That(loweredOn).IsNotNull();
+        await Assert.That(off.TryLowerVmNode(new InvokeActionEffect("Process", []))).IsNotNull();
+    }
+
+    [Test]
+    public async Task CrossEntityInvoke_Runtime_InvokesOnLinkedTarget() {
+        var (orchestrator, service, domain) = CreateLinkedDomain();
+        var store = new DomainInstanceStore();
+        var svc = DomainEntityInstance.Create(service,
+            new Dictionary<string, object?> { ["Status"] = "idle" }, domain: domain);
+        var orch = DomainEntityInstance.Create(orchestrator, domain: domain);
+        store.Add(svc);
+        store.Add(orch);
+        store.Link("ServiceCall", orch, svc);
+
+        var result = orch.InvokeAction("Run");
+
+        await Assert.That(result.Succeeded).IsTrue();
+        await Assert.That(svc.GetProperty<object>("Status")).IsEqualTo("processed");
+    }
+
+    [Test]
+    public async Task CrossEntityInvoke_Unlinked_FailsWithDomainMessage() {
+        var (orchestrator, _, domain) = CreateLinkedDomain();
+        var store = new DomainInstanceStore();
+        var orch = DomainEntityInstance.Create(orchestrator, domain: domain);
+        store.Add(orch);
+
+        await Assert.That(() => orch.InvokeAction("Run"))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("requires a linked 'ServiceCall'");
+    }
+
+    [Test]
+    public async Task Generate_CrossEntityInvoke_PrintsNavGuardAndCall() {
+        var nav = new Member(new ThisReference(), "ServiceCall");
+        var node = new Block([
+            new IfStatement(
+                new Equal(nav, new Constant(null!)),
+                new Block([new Return(new Invoke(
+                    new Member(new TypeReference("DomainResult"), "Failure"),
+                    new Constant("'Process' requires a linked 'ServiceCall' on entity 'Orchestrator'.")))])),
+            new Invoke(new Member(nav, "Process"))
+        ]);
+        var cs = new CSharpGenerator().Generate(node);
+        await Assert.That(cs).Contains("this.ServiceCall == null");
+        await Assert.That(cs).Contains("DomainResult.Failure(\"'Process' requires a linked 'ServiceCall' on entity 'Orchestrator'.\")");
+        await Assert.That(cs).Contains("this.ServiceCall.Process()");
+        await Assert.That(cs).DoesNotContain("this.ServiceCall!");
+    }
+}

--- a/Poly.Tests/DomainModeling/Lowering/SelfInvokeHostAbiTests.cs
+++ b/Poly.Tests/DomainModeling/Lowering/SelfInvokeHostAbiTests.cs
@@ -46,7 +46,7 @@ public class SelfInvokeHostAbiTests {
         await Assert.That(((Invoke)loweredOff!).Delegate).IsTypeOf<Member>();
         await Assert.That(((Member)((Invoke)loweredOff!).Delegate).MemberName).IsEqualTo("Other");
         await Assert.That(off.TryLowerVmNode(
-            new InvokeActionEffect("Other", [], TargetRelationship: "orders"))).IsNull();
+            new InvokeActionEffect("Other", [], TargetRelationship: "orders"))).IsNotNull();
     }
 
     [Test]

--- a/Poly.Tests/DomainModeling/Lowering/StageTransitionHostAbiTests.cs
+++ b/Poly.Tests/DomainModeling/Lowering/StageTransitionHostAbiTests.cs
@@ -65,7 +65,7 @@ public class StageTransitionHostAbiTests {
     }
 
     [Test]
-    public async Task CreateAndInvoke_StillNullOnRuntimePath() {
+    public async Task CreateAndForEach_StillNullOnRuntimePath() {
         var entity = CreatePersonEntity();
         var pass = new EffectLoweringPass(entity, new LoweringContext(
             new Parameter("entity"), LowerStageTransitions: false));
@@ -73,7 +73,7 @@ public class StageTransitionHostAbiTests {
         await Assert.That(pass.TryLowerVmNode(
             new CreateEntityInstance(new DomainTypeReference("Person")))).IsNull();
         await Assert.That(pass.TryLowerVmNode(
-            new InvokeActionEffect("Activate", [], TargetRelationship: "orders"))).IsNull();
+            new InvokeActionEffect("Activate", [], TargetRelationship: "orders"))).IsNotNull();
         await Assert.That(pass.TryLowerVmNode(
             new ForEachInvokeEffect("orders", "x", null, "Activate", []))).IsNull();
     }

--- a/Poly/DomainModeling/Lowering/EffectLoweringPass.cs
+++ b/Poly/DomainModeling/Lowering/EffectLoweringPass.cs
@@ -12,14 +12,12 @@ namespace Poly.DomainModeling.Lowering;
 /// like <see cref="AssignEffect"/> and <see cref="ConditionalEffect"/>.
 ///
 /// <para>Store effects other than <see cref="StageTransitionEffect"/> and
-/// self-invoke (<see cref="CreateEntityInstance"/>, cross-entity
-/// <see cref="InvokeActionEffect"/>, <see cref="ForEachInvokeEffect"/>)
+/// invoke (<see cref="CreateEntityInstance"/>, <see cref="ForEachInvokeEffect"/>)
 /// still produce <c>null</c> from <see cref="Route"/> on the runtime path
-/// and are handled by EffectExecutor. StageTransition and self-invoke
-/// (<c>InvokeActionEffect</c> with null TargetRelationship) are handwritten
-/// IR on both runtime and emit — not host-ABI nodes.
-/// <c>LowerStageTransitions</c> still gates create / for-invoke / cross-entity
-/// invoke.</para>
+/// and are handled by EffectExecutor. StageTransition, self-invoke, and
+/// singular cross-entity invoke are handwritten IR on both runtime and emit
+/// — not host-ABI nodes. <c>LowerStageTransitions</c> still gates create /
+/// for-invoke.</para>
 ///
 /// <para>When <see cref="Analysis"/> is set, lowering reads pre-computed
 /// <see cref="IAnalysisMetadata"/> instead of re-scanning domain collections.
@@ -214,7 +212,7 @@ public sealed class EffectLoweringPass : EffectDispatch<Node?> {
     /// entry effects (in try), post-transition notification nodes, then
     /// <c>Invoke(Member(Subject, "Notify"), stageName)</c> in finally.
     /// Not a host-ABI node. Not gated on <see cref="LoweringContext.LowerStageTransitions"/>
-    /// — that flag still gates create / for-invoke / cross-entity invoke.
+    /// — that flag still gates create / for-invoke.
     /// </summary>
     protected override Node? StageTransition(StageTransitionEffect t) {
         if (!_entity.Stages.Any(s =>
@@ -301,15 +299,13 @@ public sealed class EffectLoweringPass : EffectDispatch<Node?> {
     /// <summary>
     /// Self-invoke (no TargetRelationship) is handwritten IR like StageTransition:
     /// <c>Invoke(Member(Subject, actionName), args)</c> on both runtime and emit.
-    /// Not gated on <see cref="LoweringContext.LowerStageTransitions"/> — that flag
-    /// still gates create / for-invoke / cross-entity invoke.
-    /// Singular cross-entity invoke becomes this.TargetRelationship.ActionName(args)
-    /// with a linked-target guard (still flag-gated). OneToMany fan-out uses the
-    /// for-each lowering.
+    /// Singular cross-entity invoke is <c>this.Rel.Action(args)</c> with a
+    /// linked-target guard that returns <c>DomainResult.Failure</c> before deref
+    /// (never a bare NRE). Not gated on
+    /// <see cref="LoweringContext.LowerStageTransitions"/> — that flag still
+    /// gates create / for-invoke. OneToMany fan-out uses the for-each lowering.
     /// </summary>
     protected override Node? InvokeAction(InvokeActionEffect i) {
-        if (i.TargetRelationship is not null && !_lowerStageTransitions) return null;
-
         var args = new List<Node>();
         foreach (var binding in i.ParameterBindings) {
             args.Add(_expressionPass.Lower(binding.Expression, Subject));

--- a/Poly/DomainModeling/Lowering/LoweringContext.cs
+++ b/Poly/DomainModeling/Lowering/LoweringContext.cs
@@ -33,10 +33,10 @@ namespace Poly.DomainModeling.Lowering;
 /// parameters (e.g. <c>maxAmount</c>) instead of <c>this.maxAmount</c>.
 /// </param>
 /// <param name="LowerStageTransitions">
-/// When true, create / invoke / for-invoke effects lower to C#-shaped Ast
+/// When true, create / for-invoke effects lower to C#-shaped Ast
 /// (factories, method calls). Defaults to false (runtime path keeps those on
-/// EffectExecutor). <see cref="StageTransitionEffect"/> always lowers — this
-/// flag does not gate it.
+/// EffectExecutor). StageTransition and invoke always lower — this flag
+/// does not gate them.
 /// </param>
 /// <param name="Domain">Optional domain reference for cross-entity type resolution.</param>
 /// <param name="StageEnumTypeName">

--- a/Poly/DomainModeling/Runtime/DomainEntityInstance.Dictionary.cs
+++ b/Poly/DomainModeling/Runtime/DomainEntityInstance.Dictionary.cs
@@ -16,18 +16,31 @@ public sealed partial record DomainEntityInstance : IDictionary<string, object?>
     bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => false;
 
     object? IDictionary<string, object?>.this[string key] {
-        get => _values[key];
+        get {
+            if (_values.TryGetValue(key, out var stored))
+                return stored;
+            if (TryGetOneToOneNavigation(key, out var nav))
+                return nav;
+            return _values[key];
+        }
         set => _values[key] = value;
     }
 
     void IDictionary<string, object?>.Add(string key, object? value) => _values.Add(key, value);
 
-    bool IDictionary<string, object?>.ContainsKey(string key) => _values.ContainsKey(key);
+    bool IDictionary<string, object?>.ContainsKey(string key) =>
+        _values.ContainsKey(key) || TryGetOneToOneNavigation(key, out _);
 
     bool IDictionary<string, object?>.Remove(string key) => _values.Remove(key);
 
-    bool IDictionary<string, object?>.TryGetValue(string key, [MaybeNullWhen(false)] out object? value) =>
-        _values.TryGetValue(key, out value);
+    bool IDictionary<string, object?>.TryGetValue(string key, [MaybeNullWhen(false)] out object? value) {
+        if (_values.TryGetValue(key, out value))
+            return true;
+        if (TryGetOneToOneNavigation(key, out value))
+            return true;
+        value = null;
+        return false;
+    }
 
     void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) =>
         ((ICollection<KeyValuePair<string, object?>>)_values).Add(item);

--- a/Poly/DomainModeling/Runtime/DomainEntityInstance.HostAbi.cs
+++ b/Poly/DomainModeling/Runtime/DomainEntityInstance.HostAbi.cs
@@ -47,41 +47,13 @@ public sealed partial record DomainEntityInstance {
             return _instance.ExecuteCreateInRelationship(createIn, _typeProvider);
         }
 
-        protected override object? InvokeAction(InvokeActionEffect invoke) {
-            if (invoke.TargetRelationship is null)
-                throw new InvalidOperationException(
-                    "InvokeActionEffect self-invoke must lower to Ast; EffectExecutor is not the shipped path.");
-            _instance.ExecuteInvokeEffect(invoke);
-            return null;
-        }
+        protected override object? InvokeAction(InvokeActionEffect invoke) =>
+            throw new InvalidOperationException(
+                "InvokeActionEffect must lower to Ast; EffectExecutor is not the shipped path.");
 
         protected override object? ForEachInvoke(ForEachInvokeEffect efe) {
             _instance.ExecuteForEachInvoke(efe);
             return null;
-        }
-    }
-
-    /// <summary>
-    /// Resolves <paramref name="targetExpr"/> to a <see cref="DomainEntityInstance"/> and
-    /// records an instance link (source = this, target = resolved) in the store.
-    /// Target must be a <see cref="PropertyAccess"/> whose current value is a
-    /// <see cref="DomainEntityInstance"/> (set via property bag or prior effects).
-    /// Prefer <see cref="DomainInstanceStore.Link"/> for direct API linking.
-    /// </summary>
-    private void ExecuteInvokeEffect(InvokeActionEffect invoke) {
-        if (invoke.TargetRelationship is null)
-            throw new InvalidOperationException(
-                "InvokeActionEffect self-invoke must lower to Ast; EffectExecutor is not the shipped path.");
-
-        var chainedArgs = EvaluateParameterBindings(invoke.ParameterBindings);
-        var target = ResolveRelationshipTarget(invoke.TargetRelationship);
-        var nestedResult = target.InvokeAction(invoke.ActionName, chainedArgs);
-        if (!nestedResult.Succeeded) {
-            throw new InvalidOperationException(
-                nestedResult.ErrorMessage
-                ?? (nestedResult.FailedGuards.Count > 0
-                    ? $"invoke '{invoke.ActionName}' blocked by guards: {string.Join(", ", nestedResult.FailedGuards)}"
-                    : $"invoke '{invoke.ActionName}' failed."));
         }
     }
 

--- a/Poly/DomainModeling/Runtime/DomainEntityInstance.Runtime.cs
+++ b/Poly/DomainModeling/Runtime/DomainEntityInstance.Runtime.cs
@@ -62,7 +62,8 @@ public sealed partial record DomainEntityInstance {
         string entityName,
         IEnumerable<Property> properties,
         IEnumerable<Property>? extraProperties = null,
-        IEnumerable<Action>? actions = null) {
+        IEnumerable<Action>? actions = null,
+        IEnumerable<Relationship>? navigations = null) {
         var propDefs = new List<PropertyDefinitionNode>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
@@ -84,6 +85,21 @@ public sealed partial record DomainEntityInstance {
                 "CurrentStage",
                 new PrimitiveTypeReference(Prim.String),
                 Getter: new PropertyGetterDefinitionNode()));
+        }
+
+        if (navigations is not null) {
+            foreach (var nav in navigations) {
+                if (nav.Cardinality is not RelationshipCardinality.OneToOne)
+                    continue;
+                var pascal = DomainToCSharpExporter.ToPascalCase(nav.Name);
+                if (!seen.Add(pascal))
+                    continue;
+                propDefs.Add(new PropertyDefinitionNode(
+                    pascal,
+                    new TypeReference(nav.Target.TypeName),
+                    DefaultValue: new Constant(null!),
+                    Getter: new PropertyGetterDefinitionNode()));
+            }
         }
 
         var methods = new List<MethodDefinitionNode> {
@@ -130,7 +146,23 @@ public sealed partial record DomainEntityInstance {
     /// </summary>
     private TypeDefinitionNodeAnalyzer BuildActionScopedTypeDefAnalyzer(
         Action action) =>
-        BuildTypeDefAnalyzer(Entity.Name, Entity.Properties, action.Parameters, EnumerateTypeDefActions(Entity));
+        BuildTypeDefAnalyzer(Entity.Name, Entity.Properties, action.Parameters,
+            EnumerateTypeDefActions(Entity), NavigationsFor(Entity, Domain));
+
+    /// <summary>
+    /// Source-entity navigations. Prefer the domain's copy of the entity
+    /// (tests often pass a pre-redistribution entity plus a Domain that
+    /// already owns the navs).
+    /// </summary>
+    private static IEnumerable<Relationship> NavigationsFor(Entity entity, Domain? domain) {
+        if (domain is not null) {
+            var live = domain.Types.OfType<Entity>()
+                .FirstOrDefault(e => string.Equals(e.Name, entity.Name, StringComparison.Ordinal));
+            if (live is not null)
+                return live.Navigations;
+        }
+        return entity.Navigations;
+    }
 
     /// <summary>
     /// Actions on This: entity-level plus every stage's actions. Same set the
@@ -172,21 +204,39 @@ public sealed partial record DomainEntityInstance {
     }
 
     /// <summary>
-    /// Resolves the singular target for a cross-entity invoke (E3b).
-    /// Fail-closed: caller must be relationship source; exactly one outbound link.
+    /// IDictionary read of a OneToOne nav property: the linked target, or
+    /// <c>null</c> when unlinked so the lowered guard can return
+    /// <c>DomainResult.Failure</c> instead of NRE. More than one link is
+    /// fail-closed (singular invoke).
     /// </summary>
-    private DomainEntityInstance ResolveRelationshipTarget(string relationshipName) {
-        var related = GetOutboundRelatedInstances(relationshipName);
-        if (related.Count == 0)
-            throw new InvalidOperationException(
-                $"No linked instances found for relationship '{relationshipName}' on entity '{Entity.Name}'.");
+    internal bool TryGetOneToOneNavigation(string key, out object? value) {
+        value = null;
+        Relationship? match = null;
+        foreach (var nav in NavigationsFor(Entity, Domain)) {
+            if (nav.Cardinality is not RelationshipCardinality.OneToOne)
+                continue;
+            if (!string.Equals(DomainToCSharpExporter.ToPascalCase(nav.Name), key, StringComparison.Ordinal))
+                continue;
+            match = nav;
+            break;
+        }
+        if (match is null)
+            return false;
 
+        if (Store is null || Domain is null) {
+            value = null;
+            return true;
+        }
+
+        var related = Store.GetRelatedInstances(match.Name, this)
+            .Where(t => string.Equals(t.Entity.Name, match.Target.TypeName, StringComparison.Ordinal))
+            .ToList();
         if (related.Count > 1)
             throw new InvalidOperationException(
-                $"Relationship '{relationshipName}' has {related.Count} linked instances; " +
+                $"Relationship '{match.Name}' has {related.Count} linked instances; " +
                 "singular cross-entity invoke requires exactly one target.");
-
-        return related[0];
+        value = related.Count == 0 ? null : related[0];
+        return true;
     }
 
     /// <summary>

--- a/Poly/DomainModeling/Runtime/DomainEntityInstance.cs
+++ b/Poly/DomainModeling/Runtime/DomainEntityInstance.cs
@@ -122,7 +122,10 @@ public sealed partial record DomainEntityInstance {
             }
         }
 
-        var typeDefAnalyzer = BuildTypeDefAnalyzer(entity.Name, entity.Properties, actions: EnumerateTypeDefActions(entity));
+        var typeDefAnalyzer = BuildTypeDefAnalyzer(
+            entity.Name, entity.Properties,
+            actions: EnumerateTypeDefActions(entity),
+            navigations: NavigationsFor(entity, domain));
 
         // Enforce constraints at creation, matching the C# export's Create factory guards.
         // The runtime previously accepted out-of-range/pattern-violating/empty-required
@@ -363,7 +366,7 @@ public sealed partial record DomainEntityInstance {
     ///   <item>Execute each effect in declaration order:
     ///     <list type="bullet">
     ///       <item><b>VM-compiled</b> (<see cref="AssignEffect"/>, <see cref="CompositeEffect"/>, <see cref="ConditionalEffect"/>, <see cref="StageTransitionEffect"/>) → lowered to Syntax AST → compiled via <see cref="Interpreter.Compile"/> → executed via VM. StageTransition is Assignment of CurrentStage + Invoke Notify on This.</item>
-    ///       <item><b>Direct-execution</b> (<see cref="CreateEntityInstance"/>, cross-entity <see cref="InvokeActionEffect"/>, <see cref="ForEachInvokeEffect"/>) → mutates instance state directly via EffectExecutor. Self-invoke lowers to <c>Invoke(Member(This, action))</c>.</item>
+    ///       <item><b>Direct-execution</b> (<see cref="CreateEntityInstance"/>, <see cref="ForEachInvokeEffect"/>) → mutates instance state directly via EffectExecutor. Self-invoke and singular cross-entity invoke lower to <c>Invoke(Member(…))</c>.</item>
     ///     </list>
     ///   </item>
     ///   <item>On <see cref="StageTransitionEffect"/>: lowered tree sets stage then <c>Invoke(Member(This, "Notify"))</c> (store fan-out in finally).</item>
@@ -374,9 +377,9 @@ public sealed partial record DomainEntityInstance {
     /// lowered to Syntax AST, compiled, and executed via the VM.</para>
     ///
     /// <para><b>Direct-execution effects</b> (<see cref="CreateEntityInstance"/>,
-    /// cross-entity <see cref="InvokeActionEffect"/>, <see cref="ForEachInvokeEffect"/>)
-    /// mutate the instance directly. <see cref="StageTransitionEffect"/> and
-    /// self-invoke share the lowered tree with emit.</para>
+    /// <see cref="ForEachInvokeEffect"/>) mutate the instance directly.
+    /// <see cref="StageTransitionEffect"/> and invoke share the lowered tree
+    /// with emit.</para>
     /// </summary>
     /// <param name="actionName">Name of the action to invoke.</param>
     /// <param name="args">Optional parameter values injected into the property
@@ -577,9 +580,9 @@ public sealed partial record DomainEntityInstance {
         var prepared = PreprocessEffectExpressions(effect);
 
         // A composite/conditional containing remaining direct-execution sub-effects
-        // (create/create-in, cross-entity invoke, for-invoke) must run each sub-effect
-        // through this dispatcher — those still cannot lower on the runtime path.
-        // StageTransition and self-invoke now lower.
+        // (create/create-in, for-invoke) must run each sub-effect through this
+        // dispatcher — those still cannot lower on the runtime path.
+        // StageTransition and invoke now lower.
         if ((prepared is ConditionalEffect or CompositeEffect)
             && ContainsDirectExecutionEffect(prepared)) {
             ExecuteStructured(prepared, effectPass, typeProvider);
@@ -588,7 +591,7 @@ public sealed partial record DomainEntityInstance {
 
         var lowered = effectPass.TryLowerVmNode(prepared);
         if (lowered is not null) {
-            var compiled = Interpreter.CompileChecked(lowered, typeProvider);
+            var compiled = Interpreter.CompileChecked(lowered, DomainResultTypeProvider.Wrap(typeProvider));
             using var exec = Interpreter.Execute(compiled,
                 s => s.SetArgs(new object?[] { this }));
             return;
@@ -600,7 +603,7 @@ public sealed partial record DomainEntityInstance {
     /// <summary>
     /// Executes a composite/conditional structurally: evaluates the branch condition (via
     /// the VM) and routes each sub-effect through <see cref="ExecuteEffect"/> so both
-    /// VM-executable (assign, stage transition, self-invoke) and remaining direct-execution (create / cross-entity invoke) effects run.
+    /// VM-executable (assign, stage transition, invoke) and remaining direct-execution (create / for-invoke) effects run.
     /// </summary>
     private void ExecuteStructured(
         Effect effect,
@@ -618,7 +621,7 @@ public sealed partial record DomainEntityInstance {
                     entityParam,
                     PropertyTypeResolver: EffectLoweringPass.BuildPropertyTypeResolver(Entity)));
                 var lowered = pass.Lower(condition, entityParam);
-                var compiled = Interpreter.CompileChecked(lowered, typeProvider);
+                var compiled = Interpreter.CompileChecked(lowered, DomainResultTypeProvider.Wrap(typeProvider));
                 bool taken;
                 using (var exec = Interpreter.Execute(compiled,
                            s => s.SetArgs(new object?[] { this }))) {
@@ -635,11 +638,10 @@ public sealed partial record DomainEntityInstance {
     }
 
     /// <summary>True when an effect tree contains a remaining direct-execution effect
-    /// (cross-entity invoke, create/create-in, for-invoke) that the VM path would silently drop.
-    /// Self-invoke (<see cref="InvokeActionEffect.TargetRelationship"/> null) lowers.</summary>
+    /// (create/create-in, for-invoke) that the VM path would silently drop.
+    /// Invoke (self and singular cross-entity) lowers.</summary>
     private static bool ContainsDirectExecutionEffect(Effect effect) => effect switch {
-        InvokeActionEffect { TargetRelationship: not null }
-            or CreateEntityInstance or CreateEntityInRelationshipEffect
+        CreateEntityInstance or CreateEntityInRelationshipEffect
             or ForEachInvokeEffect => true,
         CompositeEffect c => c.Effects.Any(ContainsDirectExecutionEffect),
         ConditionalEffect c => (c.ThenEffects?.Any(ContainsDirectExecutionEffect) ?? false)

--- a/Poly/DomainModeling/Runtime/DomainResult.cs
+++ b/Poly/DomainModeling/Runtime/DomainResult.cs
@@ -1,0 +1,13 @@
+namespace Poly.DomainModeling.Runtime;
+
+/// <summary>
+/// VM target for the shared linked-target guard
+/// <c>Return(Invoke(Member(TypeReference("DomainResult"), "Failure"), message))</c>.
+/// Generated C# has its own <c>DomainResult</c> that returns a result object;
+/// this type throws so the same tree is fail-closed when the VM runs it.
+/// Same tree, different <c>DomainResult</c> — like Notify on This.
+/// </summary>
+public static class DomainResult {
+    public static object Failure(string message) =>
+        throw new InvalidOperationException(message);
+}

--- a/Poly/DomainModeling/Runtime/DomainResultTypeProvider.cs
+++ b/Poly/DomainModeling/Runtime/DomainResultTypeProvider.cs
@@ -1,0 +1,25 @@
+using Poly.Interpretation.Analysis.Semantics;
+using Poly.Introspection;
+using Poly.Introspection.CommonLanguageRuntime;
+
+namespace Poly.DomainModeling.Runtime;
+
+/// <summary>
+/// Resolves the short name <c>DomainResult</c> to the runtime
+/// <see cref="DomainResult"/> CLR type so
+/// <c>Invoke(Member(TypeReference("DomainResult"), "Failure"), …)</c>
+/// is a real static call. Entity type defs stay on
+/// <see cref="TypeDefinitionNodeAnalyzer"/>.
+/// </summary>
+internal sealed class DomainResultTypeProvider(ITypeDefinitionProvider inner) : ITypeDefinitionProvider {
+    public ITypeDefinition? GetTypeDefinition(string name) {
+        if (string.Equals(name, "DomainResult", StringComparison.Ordinal))
+            return ClrTypeDefinitionRegistry.Shared.GetTypeDefinition(typeof(DomainResult));
+        return inner.GetTypeDefinition(name);
+    }
+
+    public ITypeDefinition? GetTypeDefinition(Type type) => inner.GetTypeDefinition(type);
+
+    internal static ITypeDefinitionProvider Wrap(ITypeDefinitionProvider inner) =>
+        inner is DomainResultTypeProvider wrapped ? wrapped : new DomainResultTypeProvider(inner);
+}

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -34,7 +34,7 @@ MCP harness: agent supplies context → simulate that same operation AST
 | Always-legal **operations** | Each named operation is a full tree (no `Comment` / `null` / host walk as shipped meaning). Runtime and emit consume the same trees |
 | AST is the symbolic primary | Do not reintroduce a parallel “primitive IR” for product paths |
 | VM is canonical execution of a **program** (operation or algorithm) | LINQ path is secondary (oracle / reference), not a second product engine. Do not grow a domain-side interpreter beside it |
-| Domain lowers to **generic** ops | No domain-specific VM opcodes. StageTransition is type-def + Assignment + `Invoke(Member(This, "Notify"))`. Self-invoke is `Invoke(Member(This, action))`. Remaining store/clocks (`Create` / `Link` / `Outbound` / time) still dual-path |
+| Domain lowers to **generic** ops | No domain-specific VM opcodes. StageTransition is type-def + Assignment + `Invoke(Member(This, "Notify"))`. Self-invoke is `Invoke(Member(This, action))`. Cross-entity invoke is `this.Rel.Action(args)` with a `DomainResult.Failure` linked-target guard. Remaining store/clocks (`Create` / `for-invoke` / time) still dual-path |
 | Product doors are **opt-in extensions** | REST and the like load via `uses`. CLI flags seed ids only. Core seed does not emit a host |
 | MCP is the **interactive harness** | Author, inspect, simulate by supplied context. Not the `DomainSession`. Not the customer API |
 | Extend the platform **in the pipeline** | New meaning: lower to existing nodes, analyze, and/or **replace nodes** — not special-case the emitter, ABI, or one host’s type filter |

--- a/docs/plans/simple-agent-tasks/PIPELINE-STATUS.md
+++ b/docs/plans/simple-agent-tasks/PIPELINE-STATUS.md
@@ -9,10 +9,10 @@ Other indexes must **mirror** this file (or link here) — do not invent a secon
 ## Agent pick (one line)
 
 ```text
-DONE:    gpure (2026-08-07 + follow-ups 08-08); mcp-minify (2026-08-08 + follow-ups); grammar-revision (2026-08-09: v2 engine + DSL cutover + printer + review fixes); dead-dual cleanup (2026-08-09: Validation + Text.Matching deleted); domainmodeling vision-cleanup slices 1–3 (2026-08-17: one door, session.Analyze, Comment not emit-meaning); emit-session CompileMode seed-only (2026-08-24: HTTP host only via uses http / Load(HttpLibrary); bag-gated emit); host-ABI StageTransition (PR 21); host-ABI self-invoke (PR 22)
-CURRENT: host-ABI (cross-entity invoke)
+DONE:    gpure (2026-08-07 + follow-ups 08-08); mcp-minify (2026-08-08 + follow-ups); grammar-revision (2026-08-09: v2 engine + DSL cutover + printer + review fixes); dead-dual cleanup (2026-08-09: Validation + Text.Matching deleted); domainmodeling vision-cleanup slices 1–3 (2026-08-17: one door, session.Analyze, Comment not emit-meaning); emit-session CompileMode seed-only (2026-08-24: HTTP host only via uses http / Load(HttpLibrary); bag-gated emit); host-ABI StageTransition (PR 21); host-ABI self-invoke (PR 22); host-ABI cross-entity invoke (PR 23)
+CURRENT: host-ABI (for-invoke)
 ADMIT:   host-ABI
-THEN:    host-ABI remaining store effects (create / create-in / for-invoke)
+THEN:    host-ABI remaining store effects (create / create-in)
 PARKED:  pack-2 IDomainPack; mut-safety; e2e-*; pack-host “packs extend Grammar tables”; session four-slot Meaning/Emit
 PULL:    E5; EF codegen; naming cleanup
 ```
@@ -32,7 +32,7 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 | **mcp-minify** | ✅ **DONE** 2026-08-08 (+ follow-ups same day) | Catalog 46→24; DSL-only expressions; unified `add`/`remove`; follow-ups closed. |
 | **grammar-revision** | ✅ **DONE** 2026-08-09 | v2 engine (`Grammar<TToken, TTokenKind>`, examine/consume, longest-match, stateless printer) + DSL cutover; review B1–B3/N1–N3/C1 closed. Executed directly (not via plan-suite) — see [`../grammar-revision.md`](../grammar-revision.md) |
 | **emit-session** | ✅ **DONE** 2026-08-24 (CompileMode honesty) | Libraries add `INodeAnalyzer`. Spell closed. Emit reads bags, not `CompileMode`. CompileMode.All/Db seed persistence only; HTTP host requires `uses http` (catalog id `http`) or `Load(HttpLibrary)`. Remaining lies: TemporalLibrary Meaning unused; RuntimeAnalysisCache core-catalog reopen. |
-| **host-ABI** | **CURRENT** 2026-08-25 | StageTransition DONE (PR 21). Self-invoke DONE (PR 22: `Invoke(Member(This, action))`, type-def stubs for entity+stage actions, InvokeNamed fallback). CURRENT: cross-entity invoke. Create / create-in / for-invoke still EffectExecutor. Sequential transitions stale SourceStageName. |
+| **host-ABI** | **CURRENT** 2026-08-25 | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23: `this.Rel.Action(args)` + `DomainResult.Failure` guard). CURRENT: for-invoke. Create / create-in still EffectExecutor. Sequential transitions stale SourceStageName. |
 | **pack-host** | Parked (phase 1 shipped; **extension model superseded**) | TokenWriter + binders done. “Packs extend Grammar tables” is not the product contract — extension is analysis passes. pack-2 `IDomainPack` parked. |
 | **gcyc** | Parked (first admit shipped) | [`gcyc-README.md`](./gcyc-README.md) — remaining G4 unparse is THEN, not CURRENT |
 | **grammar wrap-up** | Parked | LeftAssoc live-fold — not a prereq of pack-1 TokenWriter |
@@ -58,4 +58,4 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 - **grammar-revision** ✅ DONE 2026-08-09: v2 engine + DSL cutover + printer + review fixes (B1–B3, N1–N3, C1).
 - Span-vs-fold `not`-in-chain pinned: `SpanVsFold_NotInChain_TableRejectsFoldAccepts` until wrap-up reconciles.
 - **emit-session remaining lies:** TemporalLibrary does not register Meaning handlers (design: dispatch/type-check + `TemporalPass` vocabulary bag). `RuntimeAnalysisCache` / static `DomainModelAnalyzer.Analyze` reopen a core-catalog session (vendor maps ignored). CompileMode seed-only honesty is DONE via #20.
-- **host-ABI remaining lie:** create / create-in / for-invoke / cross-entity invoke still EffectExecutor. `ExecuteStructured` remains until mixed if+create can lower. `LowerStageTransitions` still gates those effects (not StageTransition / self-invoke). Sequential transitions stale SourceStageName.
+- **host-ABI remaining lie:** create / create-in / for-invoke still EffectExecutor. `ExecuteStructured` remains until mixed if+create can lower. `LowerStageTransitions` still gates those effects (not StageTransition / invoke). Sequential transitions stale SourceStageName.

--- a/docs/plans/simple-agent-tasks/READY-TO-TASK.md
+++ b/docs/plans/simple-agent-tasks/READY-TO-TASK.md
@@ -13,7 +13,7 @@
 | — | [`gpure-README.md`](./gpure-README.md) | ✅ DONE 2026-08-07 |
 | — | [`mcp-minify-README.md`](./mcp-minify-README.md) | ✅ DONE 2026-08-08 |
 | — | emit-session | ✅ DONE 2026-08-24 (CompileMode seed-only honesty). Remaining lies: Temporal Meaning unused; RuntimeAnalysisCache core-catalog reopen. |
-| **CURRENT** | host-ABI | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). CURRENT: cross-entity invoke. THEN: create / create-in / for-invoke. |
+| **CURRENT** | host-ABI | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). CURRENT: for-invoke. THEN: create / create-in. |
 | parked | [`mut-safety-README.md`](./mut-safety-README.md) | After pack-host |
 | 3a | [`p1-README.md`](./p1-README.md) | After pack-2-gate |
 

--- a/docs/plans/v2-to-v3/master-roadmap.md
+++ b/docs/plans/v2-to-v3/master-roadmap.md
@@ -53,16 +53,16 @@ MCP / direct API as thin consumers
 
 ```text
 DONE:    … p3/p2; GI; E1; gpure (2026-08-07); mcp-minify (2026-08-08); vision-cleanup 1–3 (2026-08-17); emit-session CompileMode seed-only (2026-08-24)
-CURRENT: host-ABI (cross-entity invoke)
+CURRENT: host-ABI (for-invoke)
 ADMIT:   host-ABI
-THEN:    host-ABI remaining store effects (create / create-in / for-invoke)
+THEN:    host-ABI remaining store effects (create / create-in)
 PARKED:  mut-safety; p1 as new sugar; pack-host dialect host; outbox lock
 PULL:    E5; EF codegen; naming cleanup
 ```
 
 **Honest product claim today:** Path-prefix multi-hop; exists/where/Q3′; peer/entity when; catalog; action `→ Entity` returns. **Grammar:** product parse is Grammar-table-guided (Option A expr ladder + effect heads; printer deferred). **MCP:** DSL-only expressions; unified `add`/`remove` + `apply_dsl`. CompileMode seeds persistence only; HTTP host is `uses http`. **No** temporal DSL authoring until p1.
 
-**Focus (2026-08-25):** host-ABI cross-entity invoke. StageTransition DONE (PR 21). Self-invoke DONE (PR 22). CURRENT: [`../simple-agent-tasks/PIPELINE-STATUS.md`](../simple-agent-tasks/PIPELINE-STATUS.md).
+**Focus (2026-08-25):** host-ABI for-invoke. StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). CURRENT: [`../simple-agent-tasks/PIPELINE-STATUS.md`](../simple-agent-tasks/PIPELINE-STATUS.md).
 ---
 
 ## Archived material


### PR DESCRIPTION
## What became true

Singular cross-entity invoke (`InvokeActionEffect` with `TargetRelationship` set) is handwritten IR on both runtime and emit: `this.Rel.Action(args)` with a linked-target guard that returns `DomainResult.Failure(...)` before deref — never a bare NRE. Not gated on `LowerStageTransitions`.

- Type def stubs OneToOne nav properties (PascalCase, default null).
- `DomainEntityInstance` IDictionary reads those keys from the store (null when unlinked; >1 link fail-closed).
- Runtime `DomainResult.Failure` throws (same tree, different `DomainResult` — like Notify on This).
- `ContainsDirectExecutionEffect` no longer treats invoke as direct.
- EffectExecutor.InvokeAction always throws. `ExecuteInvokeEffect` is gone.

## Remaining lie

create / create-in / for-invoke still EffectExecutor. `ExecuteStructured` remains until mixed if+create can lower. Sequential transitions still share stale `SourceStageName` at lowering time.

## Tests

`dotnet run --project Poly.Tests/Poly.Tests.csproj` — **2257 passed** (2026-08-25).