### PR TITLE
Set CURRENT to rewrite-to-master (do not wait on create)

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -19,7 +19,7 @@ Architectural rationale → **`docs/decisions/`**. Module maps → **`Poly/*/REA
 | **Pull ≠ CURRENT** | Available when admitted, not parallel debt. |
 | **DONE same PR** | Suite gate Done → update PIPELINE-STATUS + READY-TO-TASK + master-roadmap Agent pick together. |
 
-**CURRENT truth:** [`simple-agent-tasks/PIPELINE-STATUS.md`](simple-agent-tasks/PIPELINE-STATUS.md) — **`emit-session`**.  
+**CURRENT truth:** [`simple-agent-tasks/PIPELINE-STATUS.md`](simple-agent-tasks/PIPELINE-STATUS.md) — **`rewrite-to-master`**.  
 **Vision cleanup (slices 1–3 done; remaining duals parked):** [`domainmodeling-vision-cleanup-2026-08-16.md`](domainmodeling-vision-cleanup-2026-08-16.md). Session four-slot / pack-host Grammar.Extend **superseded** — libraries add `INodeAnalyzer`.  
 **Ready suites index:** [`simple-agent-tasks/READY-TO-TASK.md`](simple-agent-tasks/READY-TO-TASK.md)  
 **Milestones:** [`v2-to-v3/master-roadmap.md`](v2-to-v3/master-roadmap.md) (mirrors Agent pick)  

--- a/docs/plans/simple-agent-tasks/PIPELINE-STATUS.md
+++ b/docs/plans/simple-agent-tasks/PIPELINE-STATUS.md
@@ -9,10 +9,10 @@ Other indexes must **mirror** this file (or link here) — do not invent a secon
 ## Agent pick (one line)
 
 ```text
-DONE:    gpure (2026-08-07 + follow-ups 08-08); mcp-minify (2026-08-08 + follow-ups); grammar-revision (2026-08-09: v2 engine + DSL cutover + printer + review fixes); dead-dual cleanup (2026-08-09: Validation + Text.Matching deleted); domainmodeling vision-cleanup slices 1–3 (2026-08-17: one door, session.Analyze, Comment not emit-meaning); emit-session CompileMode seed-only (2026-08-24: HTTP host only via uses http / Load(HttpLibrary); bag-gated emit); host-ABI StageTransition (PR 21); host-ABI self-invoke (PR 22); host-ABI cross-entity invoke (PR 23)
-CURRENT: host-ABI (for-invoke)
+DONE:    gpure (2026-08-07 + follow-ups 08-08); mcp-minify (2026-08-08 + follow-ups); grammar-revision (2026-08-09: v2 engine + DSL cutover + printer + review fixes); dead-dual cleanup (2026-08-09: Validation + Text.Matching deleted); domainmodeling vision-cleanup slices 1–3 (2026-08-17: one door, session.Analyze, Comment not emit-meaning); emit-session CompileMode seed-only (2026-08-24: HTTP host only via uses http / Load(HttpLibrary); bag-gated emit); host-ABI StageTransition (PR 21); host-ABI self-invoke (PR 22); host-ABI cross-entity invoke (PR 23); host-ABI for-invoke (PR 24)
+CURRENT: host-ABI (create / create-in)
 ADMIT:   host-ABI
-THEN:    host-ABI remaining store effects (create / create-in)
+THEN:    kill ExecuteStructured / LowerStageTransitions when it gates nothing
 PARKED:  pack-2 IDomainPack; mut-safety; e2e-*; pack-host “packs extend Grammar tables”; session four-slot Meaning/Emit
 PULL:    E5; EF codegen; naming cleanup
 ```
@@ -32,7 +32,7 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 | **mcp-minify** | ✅ **DONE** 2026-08-08 (+ follow-ups same day) | Catalog 46→24; DSL-only expressions; unified `add`/`remove`; follow-ups closed. |
 | **grammar-revision** | ✅ **DONE** 2026-08-09 | v2 engine (`Grammar<TToken, TTokenKind>`, examine/consume, longest-match, stateless printer) + DSL cutover; review B1–B3/N1–N3/C1 closed. Executed directly (not via plan-suite) — see [`../grammar-revision.md`](../grammar-revision.md) |
 | **emit-session** | ✅ **DONE** 2026-08-24 (CompileMode honesty) | Libraries add `INodeAnalyzer`. Spell closed. Emit reads bags, not `CompileMode`. CompileMode.All/Db seed persistence only; HTTP host requires `uses http` (catalog id `http`) or `Load(HttpLibrary)`. Remaining lies: TemporalLibrary Meaning unused; RuntimeAnalysisCache core-catalog reopen. |
-| **host-ABI** | **CURRENT** 2026-08-25 | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). CURRENT: for-invoke. Create / create-in still EffectExecutor. Sequential transitions stale SourceStageName. |
+| **host-ABI** | **CURRENT** 2026-08-25 | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). For-invoke DONE (PR 24). CURRENT: create / create-in still EffectExecutor. Sequential transitions stale SourceStageName. |
 | **pack-host** | Parked (phase 1 shipped; **extension model superseded**) | TokenWriter + binders done. “Packs extend Grammar tables” is not the product contract — extension is analysis passes. pack-2 `IDomainPack` parked. |
 | **gcyc** | Parked (first admit shipped) | [`gcyc-README.md`](./gcyc-README.md) — remaining G4 unparse is THEN, not CURRENT |
 | **grammar wrap-up** | Parked | LeftAssoc live-fold — not a prereq of pack-1 TokenWriter |

--- a/docs/plans/simple-agent-tasks/PIPELINE-STATUS.md
+++ b/docs/plans/simple-agent-tasks/PIPELINE-STATUS.md
@@ -10,9 +10,9 @@ Other indexes must **mirror** this file (or link here) — do not invent a secon
 
 ```text
 DONE:    gpure (2026-08-07 + follow-ups 08-08); mcp-minify (2026-08-08 + follow-ups); grammar-revision (2026-08-09: v2 engine + DSL cutover + printer + review fixes); dead-dual cleanup (2026-08-09: Validation + Text.Matching deleted); domainmodeling vision-cleanup slices 1–3 (2026-08-17: one door, session.Analyze, Comment not emit-meaning); emit-session CompileMode seed-only (2026-08-24: HTTP host only via uses http / Load(HttpLibrary); bag-gated emit); host-ABI StageTransition (PR 21); host-ABI self-invoke (PR 22); host-ABI cross-entity invoke (PR 23); host-ABI for-invoke (PR 24)
-CURRENT: host-ABI (create / create-in)
-ADMIT:   host-ABI
-THEN:    kill ExecuteStructured / LowerStageTransitions when it gates nothing
+CURRENT: rewrite-to-master (ship the strong slice; do not wait on create)
+ADMIT:   rewrite-to-master
+THEN:    parallel streams from master (create/create-in; MCP mut-safety; Grammar wrap-up; V3 naming)
 PARKED:  pack-2 IDomainPack; mut-safety; e2e-*; pack-host “packs extend Grammar tables”; session four-slot Meaning/Emit
 PULL:    E5; EF codegen; naming cleanup
 ```
@@ -32,7 +32,8 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 | **mcp-minify** | ✅ **DONE** 2026-08-08 (+ follow-ups same day) | Catalog 46→24; DSL-only expressions; unified `add`/`remove`; follow-ups closed. |
 | **grammar-revision** | ✅ **DONE** 2026-08-09 | v2 engine (`Grammar<TToken, TTokenKind>`, examine/consume, longest-match, stateless printer) + DSL cutover; review B1–B3/N1–N3/C1 closed. Executed directly (not via plan-suite) — see [`../grammar-revision.md`](../grammar-revision.md) |
 | **emit-session** | ✅ **DONE** 2026-08-24 (CompileMode honesty) | Libraries add `INodeAnalyzer`. Spell closed. Emit reads bags, not `CompileMode`. CompileMode.All/Db seed persistence only; HTTP host requires `uses http` (catalog id `http`) or `Load(HttpLibrary)`. Remaining lies: TemporalLibrary Meaning unused; RuntimeAnalysisCache core-catalog reopen. |
-| **host-ABI** | **CURRENT** 2026-08-25 | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). For-invoke DONE (PR 24). CURRENT: create / create-in still EffectExecutor. Sequential transitions stale SourceStageName. |
+| **host-ABI** | Strong slice **DONE** (PRs 21–24) | StageTransition, self-invoke, cross-entity, for-invoke same-tree. Create / create-in still EffectExecutor — **not** the rewrite-to-master gate. |
+| **rewrite-to-master** | **CURRENT** 2026-08-25 | Fast-forward rewrite onto master. Plan: [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md). |
 | **pack-host** | Parked (phase 1 shipped; **extension model superseded**) | TokenWriter + binders done. “Packs extend Grammar tables” is not the product contract — extension is analysis passes. pack-2 `IDomainPack` parked. |
 | **gcyc** | Parked (first admit shipped) | [`gcyc-README.md`](./gcyc-README.md) — remaining G4 unparse is THEN, not CURRENT |
 | **grammar wrap-up** | Parked | LeftAssoc live-fold — not a prereq of pack-1 TokenWriter |
@@ -46,6 +47,7 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 
 | Doc | Role |
 |-----|------|
+| [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md) | Merge rewrite onto master — CURRENT |
 | [`READY-TO-TASK.md`](./READY-TO-TASK.md) | Ready-suite index (mirrors this) |
 | [`../v2-to-v3/master-roadmap.md`](../v2-to-v3/master-roadmap.md) | Milestone index + Agent pick (mirrors this) |
 | [`../README.md`](../README.md) | Plans admission rules (points here for CURRENT) |
@@ -58,4 +60,5 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 - **grammar-revision** ✅ DONE 2026-08-09: v2 engine + DSL cutover + printer + review fixes (B1–B3, N1–N3, C1).
 - Span-vs-fold `not`-in-chain pinned: `SpanVsFold_NotInChain_TableRejectsFoldAccepts` until wrap-up reconciles.
 - **emit-session remaining lies:** TemporalLibrary does not register Meaning handlers (design: dispatch/type-check + `TemporalPass` vocabulary bag). `RuntimeAnalysisCache` / static `DomainModelAnalyzer.Analyze` reopen a core-catalog session (vendor maps ignored). CompileMode seed-only honesty is DONE via #20.
-- **host-ABI remaining lie:** create / create-in still EffectExecutor. `ExecuteStructured` remains until mixed if+create can lower. `LowerStageTransitions` still gates create (not StageTransition / self-invoke / cross-entity invoke / for-invoke). Sequential transitions stale SourceStageName.
+- **host-ABI remaining lie (not a merge blocker):** create / create-in still EffectExecutor. `ExecuteStructured` remains until mixed if+create can lower. `LowerStageTransitions` still gates create (not StageTransition / self-invoke / cross-entity invoke / for-invoke). Sequential transitions stale SourceStageName.
+- **rewrite-to-master:** rewrite is a fast-forward of master (merge-base = master HEAD). Ship the strong same-tree slice; create stays documented dual-path. After merge, default PR base is master and workstreams may run in parallel with exclusive file ownership.

--- a/docs/plans/simple-agent-tasks/READY-TO-TASK.md
+++ b/docs/plans/simple-agent-tasks/READY-TO-TASK.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-24  
 **Rule:** One CURRENT suite at a time.  
-**CURRENT truth:** [`PIPELINE-STATUS.md`](./PIPELINE-STATUS.md) (only) — **CURRENT: `host-ABI`**.
+**CURRENT truth:** [`PIPELINE-STATUS.md`](./PIPELINE-STATUS.md) (only) — **CURRENT: `rewrite-to-master`**.
 
 ---
 
@@ -13,7 +13,7 @@
 | — | [`gpure-README.md`](./gpure-README.md) | ✅ DONE 2026-08-07 |
 | — | [`mcp-minify-README.md`](./mcp-minify-README.md) | ✅ DONE 2026-08-08 |
 | — | emit-session | ✅ DONE 2026-08-24 (CompileMode seed-only honesty). Remaining lies: Temporal Meaning unused; RuntimeAnalysisCache core-catalog reopen. |
-| **CURRENT** | host-ABI | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). For-invoke DONE (PR 24). CURRENT: create / create-in. |
+| **CURRENT** | rewrite-to-master | Fast-forward rewrite onto master. Strong host-ABI slice DONE (PRs 21–24). Create / create-in is a post-merge DomainModeling stream, not the merge gate. Plan: [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md). |
 | parked | [`mut-safety-README.md`](./mut-safety-README.md) | After pack-host |
 | 3a | [`p1-README.md`](./p1-README.md) | After pack-2-gate |
 

--- a/docs/plans/simple-agent-tasks/READY-TO-TASK.md
+++ b/docs/plans/simple-agent-tasks/READY-TO-TASK.md
@@ -13,7 +13,7 @@
 | — | [`gpure-README.md`](./gpure-README.md) | ✅ DONE 2026-08-07 |
 | — | [`mcp-minify-README.md`](./mcp-minify-README.md) | ✅ DONE 2026-08-08 |
 | — | emit-session | ✅ DONE 2026-08-24 (CompileMode seed-only honesty). Remaining lies: Temporal Meaning unused; RuntimeAnalysisCache core-catalog reopen. |
-| **CURRENT** | host-ABI | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). CURRENT: for-invoke. THEN: create / create-in. |
+| **CURRENT** | host-ABI | StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). For-invoke DONE (PR 24). CURRENT: create / create-in. |
 | parked | [`mut-safety-README.md`](./mut-safety-README.md) | After pack-host |
 | 3a | [`p1-README.md`](./p1-README.md) | After pack-2-gate |
 

--- a/docs/plans/simple-agent-tasks/rewrite-to-master-2026-08-25.md
+++ b/docs/plans/simple-agent-tasks/rewrite-to-master-2026-08-25.md
@@ -1,0 +1,66 @@
+# Goal: merge the DomainModeling rewrite to `master`
+
+**Date:** 2026-08-25  
+**Status:** CURRENT  
+**Does not wait on:** create / create-in leaving EffectExecutor.
+
+## Goal
+
+Fast-forward `rewrite/domainmodeling-from-scratch` onto `master` and treat **that** as the product trunk, so agents can work in **separate workstreams** from `master` instead of serializing on the rewrite branch.
+
+`origin/master` is the merge-base of rewrite. Merge is a fast-forward (581 commits, 0 unique on master).
+
+## Shipped claim (strong implementations)
+
+Same-tree runtime + emit (VM canonical):
+
+| Operation | Tree |
+|-----------|------|
+| Assign / if / composite | Syntax nodes |
+| Stage transition | `CurrentStage` assign + `Invoke(Member(This, "Notify"))` in `finally` |
+| Self-invoke | `Invoke(Member(This, action), args)` |
+| Cross-entity invoke | `this.Rel.Action(args)` + linked-target `DomainResult.Failure` guard |
+| For-invoke | OneToMany `ForEachLoop` + `InvokeNamed` + `if (!result.IsSuccess) return result` + zero-match Failure |
+
+Also strong: Grammar-table `.poly`; `DomainSession` analyze/emit; MCP harness (author / inspect / simulate with caller context); HTTP host only via `uses http`; core test suite green on rewrite.
+
+## Not a merge blocker (documented residual)
+
+Keep these as **debt on master**. Do not grow them. Do not hold the merge.
+
+- **create / create-in** — emit lowers (gated on `LowerStageTransitions`); runtime is still EffectExecutor
+- **`ExecuteStructured`** — mixed `if`+create
+- Sequential transitions share stale `SourceStageName`
+- `RuntimeAnalysisCache` core-catalog reopen; Temporal Meaning unused
+- S1 `not`-in-chain span vs fold
+- Self/cross-entity lowering does not wrap `IsSuccess` (for-invoke does)
+
+`create` stays in the shipped DSL. Dual-path is honest residual, not a silent claim that create is same-tree.
+
+## Merge checklist
+
+1. Land this CURRENT bump (this PR / plan). Close the “CURRENT is create/create-in” story as a merge blocker.
+2. Confirm `dotnet run --project Poly.Tests/Poly.Tests.csproj` green on rewrite HEAD.
+3. Open PR **rewrite → master** (fast-forward). Description = this shipped claim + residual list.
+4. After merge: default PR base is `master`. Agents do not open work on `rewrite/domainmodeling-from-scratch`.
+5. Then admit **parallel** workstreams (below). One stream still owns any given file.
+
+## After master: parallel workstreams
+
+Admission becomes **one owner per file**, not one suite for the whole repo.
+
+| Stream | Owns | Does not touch |
+|--------|------|----------------|
+| **create / create-in** | `DomainModeling` lowering + `EffectExecutor` + `ExecuteStructured` | Grammar tables, MCP tool catalog |
+| **MCP mut-safety** | `Poly.Mcp` session lock / idempotent add | Domain lowering, VM emitter |
+| **Grammar wrap-up** | Grammar engine + live-fold S1 | Domain runtime, host-ABI |
+| **Naming (`V3*`)** | rename-only (`post-v2-delete-naming-cleanup`) | behavior |
+
+Create/create-in is the next **DomainModeling** slice after trunk lands. It is not the rewrite-to-master gate.
+
+## Out of scope for this merge
+
+- Finishing host-ABI create
+- Killing `ExecuteStructured` / `LowerStageTransitions`
+- Byte-identical `Poly.dll`
+- Requiring every domain to `uses http`

--- a/docs/plans/v2-to-v3/master-roadmap.md
+++ b/docs/plans/v2-to-v3/master-roadmap.md
@@ -52,17 +52,17 @@ MCP / direct API as thin consumers
 ### Agent pick (one line)
 
 ```text
-DONE:    … p3/p2; GI; E1; gpure (2026-08-07); mcp-minify (2026-08-08); vision-cleanup 1–3 (2026-08-17); emit-session CompileMode seed-only (2026-08-24)
-CURRENT: host-ABI (for-invoke)
+DONE:    … p3/p2; GI; E1; gpure (2026-08-07); mcp-minify (2026-08-08); vision-cleanup 1–3 (2026-08-17); emit-session CompileMode seed-only (2026-08-24); host-ABI PRs 21–24
+CURRENT: host-ABI (create / create-in)
 ADMIT:   host-ABI
-THEN:    host-ABI remaining store effects (create / create-in)
+THEN:    kill ExecuteStructured / LowerStageTransitions when it gates nothing
 PARKED:  mut-safety; p1 as new sugar; pack-host dialect host; outbox lock
 PULL:    E5; EF codegen; naming cleanup
 ```
 
 **Honest product claim today:** Path-prefix multi-hop; exists/where/Q3′; peer/entity when; catalog; action `→ Entity` returns. **Grammar:** product parse is Grammar-table-guided (Option A expr ladder + effect heads; printer deferred). **MCP:** DSL-only expressions; unified `add`/`remove` + `apply_dsl`. CompileMode seeds persistence only; HTTP host is `uses http`. **No** temporal DSL authoring until p1.
 
-**Focus (2026-08-25):** host-ABI for-invoke. StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). CURRENT: [`../simple-agent-tasks/PIPELINE-STATUS.md`](../simple-agent-tasks/PIPELINE-STATUS.md).
+**Focus (2026-08-25):** host-ABI create / create-in. StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). For-invoke DONE (PR 24). CURRENT: [`../simple-agent-tasks/PIPELINE-STATUS.md`](../simple-agent-tasks/PIPELINE-STATUS.md).
 ---
 
 ## Archived material

--- a/docs/plans/v2-to-v3/master-roadmap.md
+++ b/docs/plans/v2-to-v3/master-roadmap.md
@@ -53,16 +53,16 @@ MCP / direct API as thin consumers
 
 ```text
 DONE:    … p3/p2; GI; E1; gpure (2026-08-07); mcp-minify (2026-08-08); vision-cleanup 1–3 (2026-08-17); emit-session CompileMode seed-only (2026-08-24); host-ABI PRs 21–24
-CURRENT: host-ABI (create / create-in)
-ADMIT:   host-ABI
-THEN:    kill ExecuteStructured / LowerStageTransitions when it gates nothing
+CURRENT: rewrite-to-master (ship the strong slice; do not wait on create)
+ADMIT:   rewrite-to-master
+THEN:    parallel streams from master (create/create-in; MCP mut-safety; Grammar wrap-up; V3 naming)
 PARKED:  mut-safety; p1 as new sugar; pack-host dialect host; outbox lock
 PULL:    E5; EF codegen; naming cleanup
 ```
 
 **Honest product claim today:** Path-prefix multi-hop; exists/where/Q3′; peer/entity when; catalog; action `→ Entity` returns. **Grammar:** product parse is Grammar-table-guided (Option A expr ladder + effect heads; printer deferred). **MCP:** DSL-only expressions; unified `add`/`remove` + `apply_dsl`. CompileMode seeds persistence only; HTTP host is `uses http`. **No** temporal DSL authoring until p1.
 
-**Focus (2026-08-25):** host-ABI create / create-in. StageTransition DONE (PR 21). Self-invoke DONE (PR 22). Cross-entity invoke DONE (PR 23). For-invoke DONE (PR 24). CURRENT: [`../simple-agent-tasks/PIPELINE-STATUS.md`](../simple-agent-tasks/PIPELINE-STATUS.md).
+**Focus (2026-08-25):** merge rewrite to master. Strong host-ABI slice DONE (PRs 21–24). Create / create-in is post-merge. Plan: [`../simple-agent-tasks/rewrite-to-master-2026-08-25.md`](../simple-agent-tasks/rewrite-to-master-2026-08-25.md). CURRENT: [`../simple-agent-tasks/PIPELINE-STATUS.md`](../simple-agent-tasks/PIPELINE-STATUS.md).
 ---
 
 ## Archived material


### PR DESCRIPTION
## Summary

Goal: fast-forward `rewrite/domainmodeling-from-scratch` onto `master` with the strong same-tree slice (stage / self-invoke / cross-entity / for-invoke). Create / create-in stays documented dual-path — not the merge gate.

Plan: `docs/plans/simple-agent-tasks/rewrite-to-master-2026-08-25.md`

Does not merge rewrite to master by itself. After this lands, open rewrite → master.