### PR TITLE
Mark rewrite-to-master DONE; parallel streams from master

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -9,7 +9,7 @@ Architectural rationale → **`docs/decisions/`**. Module maps → **`Poly/*/REA
 
 ## Admission control
 
-**One primary implementation workstream at a time.**
+**Trunk is `master`.** Parallel implementation streams are admitted after rewrite-to-master (PR 26). One owner per file; do not serialize the whole repo on a single suite.
 
 | Rule | Meaning |
 |------|---------|
@@ -19,7 +19,7 @@ Architectural rationale → **`docs/decisions/`**. Module maps → **`Poly/*/REA
 | **Pull ≠ CURRENT** | Available when admitted, not parallel debt. |
 | **DONE same PR** | Suite gate Done → update PIPELINE-STATUS + READY-TO-TASK + master-roadmap Agent pick together. |
 
-**CURRENT truth:** [`simple-agent-tasks/PIPELINE-STATUS.md`](simple-agent-tasks/PIPELINE-STATUS.md) — **`rewrite-to-master`**.  
+**CURRENT truth:** [`simple-agent-tasks/PIPELINE-STATUS.md`](simple-agent-tasks/PIPELINE-STATUS.md) — **`(none)`**; trunk is `master`; parallel streams with exclusive files.  
 **Vision cleanup (slices 1–3 done; remaining duals parked):** [`domainmodeling-vision-cleanup-2026-08-16.md`](domainmodeling-vision-cleanup-2026-08-16.md). Session four-slot / pack-host Grammar.Extend **superseded** — libraries add `INodeAnalyzer`.  
 **Ready suites index:** [`simple-agent-tasks/READY-TO-TASK.md`](simple-agent-tasks/READY-TO-TASK.md)  
 **Milestones:** [`v2-to-v3/master-roadmap.md`](v2-to-v3/master-roadmap.md) (mirrors Agent pick)  

--- a/docs/plans/simple-agent-tasks/PIPELINE-STATUS.md
+++ b/docs/plans/simple-agent-tasks/PIPELINE-STATUS.md
@@ -9,10 +9,10 @@ Other indexes must **mirror** this file (or link here) — do not invent a secon
 ## Agent pick (one line)
 
 ```text
-DONE:    gpure (2026-08-07 + follow-ups 08-08); mcp-minify (2026-08-08 + follow-ups); grammar-revision (2026-08-09: v2 engine + DSL cutover + printer + review fixes); dead-dual cleanup (2026-08-09: Validation + Text.Matching deleted); domainmodeling vision-cleanup slices 1–3 (2026-08-17: one door, session.Analyze, Comment not emit-meaning); emit-session CompileMode seed-only (2026-08-24: HTTP host only via uses http / Load(HttpLibrary); bag-gated emit); host-ABI StageTransition (PR 21); host-ABI self-invoke (PR 22); host-ABI cross-entity invoke (PR 23); host-ABI for-invoke (PR 24)
-CURRENT: rewrite-to-master (ship the strong slice; do not wait on create)
-ADMIT:   rewrite-to-master
-THEN:    parallel streams from master (create/create-in; MCP mut-safety; Grammar wrap-up; V3 naming)
+DONE:    gpure (2026-08-07 + follow-ups 08-08); mcp-minify (2026-08-08 + follow-ups); grammar-revision (2026-08-09: v2 engine + DSL cutover + printer + review fixes); dead-dual cleanup (2026-08-09: Validation + Text.Matching deleted); domainmodeling vision-cleanup slices 1–3 (2026-08-17: one door, session.Analyze, Comment not emit-meaning); emit-session CompileMode seed-only (2026-08-24: HTTP host only via uses http / Load(HttpLibrary); bag-gated emit); host-ABI StageTransition (PR 21); host-ABI self-invoke (PR 22); host-ABI cross-entity invoke (PR 23); host-ABI for-invoke (PR 24); rewrite-to-master (PR 26)
+CURRENT: (none) — parallel streams admitted from master
+ADMIT:   parallel (exclusive files)
+THEN:    create/create-in; MCP mut-safety; Grammar wrap-up; V3 naming
 PARKED:  pack-2 IDomainPack; mut-safety; e2e-*; pack-host “packs extend Grammar tables”; session four-slot Meaning/Emit
 PULL:    E5; EF codegen; naming cleanup
 ```
@@ -33,7 +33,7 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 | **grammar-revision** | ✅ **DONE** 2026-08-09 | v2 engine (`Grammar<TToken, TTokenKind>`, examine/consume, longest-match, stateless printer) + DSL cutover; review B1–B3/N1–N3/C1 closed. Executed directly (not via plan-suite) — see [`../grammar-revision.md`](../grammar-revision.md) |
 | **emit-session** | ✅ **DONE** 2026-08-24 (CompileMode honesty) | Libraries add `INodeAnalyzer`. Spell closed. Emit reads bags, not `CompileMode`. CompileMode.All/Db seed persistence only; HTTP host requires `uses http` (catalog id `http`) or `Load(HttpLibrary)`. Remaining lies: TemporalLibrary Meaning unused; RuntimeAnalysisCache core-catalog reopen. |
 | **host-ABI** | Strong slice **DONE** (PRs 21–24) | StageTransition, self-invoke, cross-entity, for-invoke same-tree. Create / create-in still EffectExecutor — **not** the rewrite-to-master gate. |
-| **rewrite-to-master** | **CURRENT** 2026-08-25 | Fast-forward rewrite onto master. Plan: [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md). |
+| **rewrite-to-master** | ✅ **DONE** 2026-08-25 (PR 26) | Rewrite is `master`. Plan: [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md). New work from `master`; do not open work on the rewrite branch. |
 | **pack-host** | Parked (phase 1 shipped; **extension model superseded**) | TokenWriter + binders done. “Packs extend Grammar tables” is not the product contract — extension is analysis passes. pack-2 `IDomainPack` parked. |
 | **gcyc** | Parked (first admit shipped) | [`gcyc-README.md`](./gcyc-README.md) — remaining G4 unparse is THEN, not CURRENT |
 | **grammar wrap-up** | Parked | LeftAssoc live-fold — not a prereq of pack-1 TokenWriter |
@@ -47,7 +47,7 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 
 | Doc | Role |
 |-----|------|
-| [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md) | Merge rewrite onto master — CURRENT |
+| [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md) | Merge rewrite onto master — ✅ DONE PR 26 |
 | [`READY-TO-TASK.md`](./READY-TO-TASK.md) | Ready-suite index (mirrors this) |
 | [`../v2-to-v3/master-roadmap.md`](../v2-to-v3/master-roadmap.md) | Milestone index + Agent pick (mirrors this) |
 | [`../README.md`](../README.md) | Plans admission rules (points here for CURRENT) |
@@ -61,4 +61,4 @@ opencode run --dir . --auto --title pack-1-1 --agent build "Assigned: docs/plans
 - Span-vs-fold `not`-in-chain pinned: `SpanVsFold_NotInChain_TableRejectsFoldAccepts` until wrap-up reconciles.
 - **emit-session remaining lies:** TemporalLibrary does not register Meaning handlers (design: dispatch/type-check + `TemporalPass` vocabulary bag). `RuntimeAnalysisCache` / static `DomainModelAnalyzer.Analyze` reopen a core-catalog session (vendor maps ignored). CompileMode seed-only honesty is DONE via #20.
 - **host-ABI remaining lie (not a merge blocker):** create / create-in still EffectExecutor. `ExecuteStructured` remains until mixed if+create can lower. `LowerStageTransitions` still gates create (not StageTransition / self-invoke / cross-entity invoke / for-invoke). Sequential transitions stale SourceStageName.
-- **rewrite-to-master:** rewrite is a fast-forward of master (merge-base = master HEAD). Ship the strong same-tree slice; create stays documented dual-path. After merge, default PR base is master and workstreams may run in parallel with exclusive file ownership.
+- **rewrite-to-master:** ✅ DONE PR 26. Product trunk is `master`. Parallel streams may run with exclusive file ownership (create/create-in; MCP mut-safety; Grammar wrap-up; V3 naming).

--- a/docs/plans/simple-agent-tasks/READY-TO-TASK.md
+++ b/docs/plans/simple-agent-tasks/READY-TO-TASK.md
@@ -1,8 +1,8 @@
 # Plans ready for agent micro-tasks
 
-**Date:** 2026-08-24  
-**Rule:** One CURRENT suite at a time.  
-**CURRENT truth:** [`PIPELINE-STATUS.md`](./PIPELINE-STATUS.md) (only) — **CURRENT: `rewrite-to-master`**.
+**Date:** 2026-08-25  
+**Rule:** Trunk is `master`. Parallel streams with exclusive file ownership.  
+**CURRENT truth:** [`PIPELINE-STATUS.md`](./PIPELINE-STATUS.md) (only) — **CURRENT: `(none)` — parallel streams from `master`**.
 
 ---
 
@@ -13,7 +13,7 @@
 | — | [`gpure-README.md`](./gpure-README.md) | ✅ DONE 2026-08-07 |
 | — | [`mcp-minify-README.md`](./mcp-minify-README.md) | ✅ DONE 2026-08-08 |
 | — | emit-session | ✅ DONE 2026-08-24 (CompileMode seed-only honesty). Remaining lies: Temporal Meaning unused; RuntimeAnalysisCache core-catalog reopen. |
-| **CURRENT** | rewrite-to-master | Fast-forward rewrite onto master. Strong host-ABI slice DONE (PRs 21–24). Create / create-in is a post-merge DomainModeling stream, not the merge gate. Plan: [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md). |
+| — | rewrite-to-master | ✅ DONE PR 26. Trunk is `master`. Plan: [`rewrite-to-master-2026-08-25.md`](./rewrite-to-master-2026-08-25.md). |
 | parked | [`mut-safety-README.md`](./mut-safety-README.md) | After pack-host |
 | 3a | [`p1-README.md`](./p1-README.md) | After pack-2-gate |
 

--- a/docs/plans/simple-agent-tasks/rewrite-to-master-2026-08-25.md
+++ b/docs/plans/simple-agent-tasks/rewrite-to-master-2026-08-25.md
@@ -1,7 +1,7 @@
 # Goal: merge the DomainModeling rewrite to `master`
 
 **Date:** 2026-08-25  
-**Status:** CURRENT  
+**Status:** ✅ DONE (PR 26)  
 **Does not wait on:** create / create-in leaving EffectExecutor.
 
 ## Goal

--- a/docs/plans/v2-to-v3/master-roadmap.md
+++ b/docs/plans/v2-to-v3/master-roadmap.md
@@ -53,16 +53,16 @@ MCP / direct API as thin consumers
 
 ```text
 DONE:    … p3/p2; GI; E1; gpure (2026-08-07); mcp-minify (2026-08-08); vision-cleanup 1–3 (2026-08-17); emit-session CompileMode seed-only (2026-08-24); host-ABI PRs 21–24
-CURRENT: rewrite-to-master (ship the strong slice; do not wait on create)
-ADMIT:   rewrite-to-master
-THEN:    parallel streams from master (create/create-in; MCP mut-safety; Grammar wrap-up; V3 naming)
+CURRENT: (none) — parallel streams admitted from master
+ADMIT:   parallel (exclusive files)
+THEN:    create/create-in; MCP mut-safety; Grammar wrap-up; V3 naming
 PARKED:  mut-safety; p1 as new sugar; pack-host dialect host; outbox lock
 PULL:    E5; EF codegen; naming cleanup
 ```
 
 **Honest product claim today:** Path-prefix multi-hop; exists/where/Q3′; peer/entity when; catalog; action `→ Entity` returns. **Grammar:** product parse is Grammar-table-guided (Option A expr ladder + effect heads; printer deferred). **MCP:** DSL-only expressions; unified `add`/`remove` + `apply_dsl`. CompileMode seeds persistence only; HTTP host is `uses http`. **No** temporal DSL authoring until p1.
 
-**Focus (2026-08-25):** merge rewrite to master. Strong host-ABI slice DONE (PRs 21–24). Create / create-in is post-merge. Plan: [`../simple-agent-tasks/rewrite-to-master-2026-08-25.md`](../simple-agent-tasks/rewrite-to-master-2026-08-25.md). CURRENT: [`../simple-agent-tasks/PIPELINE-STATUS.md`](../simple-agent-tasks/PIPELINE-STATUS.md).
+**Focus (2026-08-25):** rewrite is `master` (PR 26). Parallel streams from trunk. Plan: [`../simple-agent-tasks/rewrite-to-master-2026-08-25.md`](../simple-agent-tasks/rewrite-to-master-2026-08-25.md). CURRENT: [`../simple-agent-tasks/PIPELINE-STATUS.md`](../simple-agent-tasks/PIPELINE-STATUS.md).
 ---
 
 ## Archived material


### PR DESCRIPTION
## Summary

PR 26 landed the DomainModeling rewrite on \`master\`. CURRENT is \`(none)\`. Parallel streams (exclusive files): create/create-in, MCP mut-safety, Grammar wrap-up, V3 naming.