### PR TITLE
docs: note LowerStageTransitions no longer gates invoke

### DIFF
--- a/docs/agent/reviews/2026-08-15-vision-cleanup-plan-review.md
+++ b/docs/agent/reviews/2026-08-15-vision-cleanup-plan-review.md
@@ -1,5 +1,7 @@
 # Vision cleanup plan — 2026-08-15
 
+**Status (2026-08-25):** Findings below are unchanged. Issue 4 correctly described `LowerStageTransitions` gating invoke / for-invoke / create at review time. As of PRs 21–24, that flag no longer gates StageTransition, self-invoke, cross-entity invoke, or for-invoke — only create / create-in. The invoke-gating claim is historically true and currently stale.
+
 - **Target**: paths `docs/plans/domainmodeling-vision-cleanup-2026-08-15.md` vs current `HEAD` + dirty tree (plan claims, not a code diff)
 - **Mode**: standard
 - **Issue counts**: 5 bugs, 8 suggestions, 4 nits


### PR DESCRIPTION
## Summary

Adds a 2026-08-25 status note at the top of `docs/agent/reviews/2026-08-15-vision-cleanup-plan-review.md`. Findings are not rewritten.

Issue 4 correctly described `LowerStageTransitions` gating invoke / for-invoke / create at review time. As of PRs 21–24 that flag no longer gates StageTransition, self-invoke, cross-entity invoke, or for-invoke — only create / create-in. The invoke-gating claim is historically true and currently stale.

## Test plan

- Docs-only; no code change.