### PR TITLE
docs: drop stale agent-guide ban of for-invoke

### DIFF
--- a/Poly.Mcp/Docs/poly-dsl-agent-guide.md
+++ b/Poly.Mcp/Docs/poly-dsl-agent-guide.md
@@ -464,7 +464,6 @@ The following effects exist in the runtime library but have **no DSL syntax** ye
 |-----------|-----|
 | `actor` | Use `entity` instead |
 | `schedule`, `parallel` | Not product constructs |
-| `schedule`, `parallel`, `for` | Control flow not supported |
 
 | `relationship Name from A to B` | Use N1 nav properties instead |
 | `function` | Functions not supported |


### PR DESCRIPTION
## Summary
Product `invoke` / `for Rel as name invoke` / `transition` are the same lowered AST as emit; the VM runs them. Neither product nor agent guide described those as host escapes, `Comment`, `EffectExecutor`, or `CallExternal`. Create/create-in already stay honest as runtime-store dual-path.

The agent guide still listed `for` under **Do NOT Use** (`schedule`, `parallel`, `for` — control flow not supported) while documenting the shipped fan-out form. Removed that stale row so it matches the product guide.

## Files
- `Poly.Mcp/Docs/poly-dsl-agent-guide.md` — drop unsupported-`for` row
- `Poly.Mcp/Docs/poly-dsl-guide.md` — no change